### PR TITLE
Add vscode devcontainer for easy documentation editing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
+{
+	"name": "Jekyll",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "jekyll --version"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,22 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
 {
-	"name": "Jekyll",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+  "name": "Jekyll",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "jekyll --version"
+  // Uncomment the next line to run commands after the container is created.
+  // "postCreateCommand": "jekyll --version"
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "root"
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:4000",
+      "webRoot": "${workspaceFolder}",
+      "preLaunchTask": "Run Jekyll"
+    },
+    {
+      "name": "Launch Edge",
+      "request": "launch",
+      "type": "msedge",
+      "url": "http://localhost:4000/",
+      "webRoot": "${workspaceFolder}",
+      "preLaunchTask": "Run Jekyll"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
       "name": "Launch Chrome",
       "request": "launch",
       "type": "chrome",
-      "url": "http://localhost:4000",
+      "url": "http://127.0.0.1:4000",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "Run Jekyll"
     },
@@ -12,7 +12,7 @@
       "name": "Launch Edge",
       "request": "launch",
       "type": "msedge",
-      "url": "http://localhost:4000/",
+      "url": "http://127.0.0.1:4000/",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "Run Jekyll"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-	"files.exclude": {
-		"**/_site": true,
-		"**/.jekyll-cache": true
-	}
+  "files.exclude": {
+    "**/_site": true,
+    "**/.jekyll-cache": true,
+    "**/.ruby-lsp": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"files.exclude": {
+		"**/_site": true,
+		"**/.jekyll-cache": true
+	}
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Jekyll",
+      "type": "shell",
+      "command": "bundle exec jekyll serve --livereload",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "Server running .*",
+          "file": 1,
+          "location": 2,
+          "message": 0
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\s*Generating\\.\\.\\.",
+          "endsPattern": "^\\s*Server running\\.\\.\\. press ctrl-c to stop\\."
+        }
+      },
+      "isBackground": true,
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ them is using [Visual Studio Code](http://code.visualstudio.com/).
 1. Fork the repo
 2. Clone it locally
 3. Open the repo in VSCode
-4. When prompted click `Reopen in devcontainer`
+4. When prompted click `Reopen in Container`
 5. Wait for the devcontainer to build
 
 ## Testing documentation changes
@@ -22,4 +22,4 @@ The repo is set up with `F5` deployment in VSCode. Simply press `F5` and the doc
 and launch in a browser. Once run, documentation changes will automatically get rebuilt.
 
 VSCode launch profiles for Chrome and Edge are provided, simply select the launch profile you want
-in the debug tab. 
+in the debug tab.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,18 @@ them is using [Visual Studio Code](http://code.visualstudio.com/).
 1. Install [Docker](https://www.docker.com/get-started/)
 2. Install [Visual Studio Code](https://code.visualstudio.com/Download) and the [devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
-## Using the devcontainer
+## Using the devcontainer (Mac and Windows)
+
+1. Fork the repo
+2. Run VSCode
+3. Select `Dev Containers: Clone Repository in Container Volume...`
+4. Follow the prompts to authenticate with GitHub and select the forked repo
+5. Select `master` as the branch
+6. Wait for the devcontainer to build
+
+Cloning the repository in a container volume greatly improves performance, and on Windows ensures live updating works.
+
+## Using the devcontainer (Linux)
 
 1. Fork the repo
 2. Clone it locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing documentation
+
+This documentation is published using Jekyll. The easiest way to write updates and test
+them is using [Visual Studio Code](http://code.visualstudio.com/).
+
+## Pre-requisites
+
+1. Install [Docker](https://www.docker.com/get-started/)
+2. Install [Visual Studio Code](https://code.visualstudio.com/Download) and the [devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## Using the devcontainer
+
+1. Fork the repo
+2. Clone it locally
+3. Open the repo in VSCode
+4. When prompted click `Reopen in devcontainer`
+5. Wait for the devcontainer to build
+
+## Testing documentation changes
+
+The repo is set up with `F5` deployment in VSCode. Simply press `F5` and the documentation will build
+and launch in a browser. Once run, documentation changes will automatically get rebuilt.
+
+VSCode launch profiles for Chrome and Edge are provided, simply select the launch profile you want
+in the debug tab. 

--- a/_config.yml
+++ b/_config.yml
@@ -76,3 +76,5 @@ callouts:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
+exclude:
+  - CONTRIBUTING.md


### PR DESCRIPTION
Jekyll isn't really made to run on Windows, which is a pain. This PR adds the necessary files to enable easy documentation editing using devcontainers and VSCode.

* `.gitattributes`: Configure line endings so there aren't constant fights between Windows and non-Windows platforms
* `.devcontainer\devcontainer.json`: Container configuration using the Microsoft-published image for Jekyll development
* `.vscode\launch.json`: Launch profiles for Chrome and Edge to enable `F5` build and run
* `.vscode\.settings.json`: Hide cache and build output folders from VSCode's explorer
* `.vscode\tasks.json`: Task definition for running Jekyll watch build, with problem matchers to detect when the build is complete and the server is running
* `CONTRIBUTING.md`: Information on how to set up to quickly build the docs locally

What does this all look like to the content author? When you open the cloned repo in VSCode you get this prompt:

![image](https://github.com/user-attachments/assets/8d887669-f202-43da-9b24-325f3afb5b2e)

Then you hit `Reopen in Container`, wait a bit, and voila. You can work on the documentation. No installs of Ruby, Jekyll, etc. needed.