### PR TITLE
Remove note about text ordering

### DIFF
--- a/docs/client/airport-conditions.markdown
+++ b/docs/client/airport-conditions.markdown
@@ -23,6 +23,3 @@ When composing or modifying a message, you can insert contractions by typing the
 
 ### Include Before Free-form Airport Conditions
 If enabled, the checked static messages will be included before the free-form Airport Conditions text in the ATIS.
-
-{: .note }
-The main window always shows static messages in front of the free-form airport conditions, regardless of this setting. Text and voice ATIS messages will include the static messages in the correct location.

--- a/docs/client/notams.markdown
+++ b/docs/client/notams.markdown
@@ -23,6 +23,3 @@ When composing or modifying a message, you can insert contractions by typing the
 
 ### Include Before Free-form NOTAMs
 If enabled, the checked static messages will be included before the free-form NOTAMs text in the ATIS.
-
-{: .note }
-The main window always shows static messages in front of the free-form NOTAMs, regardless of this setting. Text and voice ATIS messages will include the static messages in the correct location.


### PR DESCRIPTION
Removes the note added in #18. It isn't just a straight revert because I fixed an alt text bug in the original PR and that should stay.